### PR TITLE
Remove deprecated react/jsx-space-before-closing rule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,11 @@ script:
 - npm run lint
 - npm run lerna:bootstrap
 - npm run lerna:exec -- cp ../../LICENSE .
-- .travis/publish.sh
+
+deploy:
+  provider: script
+  script: bash .travis/publish.sh
+  on:
+    tags: true
+    all_branches: true
+    condition: $TRAVIS_BRANCH = master

--- a/.travis/publish.sh
+++ b/.travis/publish.sh
@@ -1,19 +1,11 @@
 #!/bin/bash
 
-BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
-BRANCH_REGEX="^(release//*)"
+echo "Publishing release $TRAVIS_TAG"
 
-echo Current branch is $BRANCH
-
-if [[ $BRANCH =~ $BRANCH_REGEX ]] ; then
-
-  if [[ -z "$NPM_TOKEN" ]] ; then
-    echo "NPM_TOKEN must be defined"
-    exit 1
-  fi
-
-  echo //registry.npmjs.org/:_authToken=$NPM_TOKEN > ~/.npmrc
-  npm run lerna:publish
-else
-  echo Skipping publication
+if [[ -z "$NPM_TOKEN" ]] ; then
+  echo "NPM_TOKEN must be defined"
+  exit 1
 fi
+
+echo //registry.npmjs.org/:_authToken=$NPM_TOKEN > ~/.npmrc
+npm run lerna:publish

--- a/packages/eslint-config-adidas-react/CHANGELOG.md
+++ b/packages/eslint-config-adidas-react/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1
+
+- Removed deprecated rule `react/jsx-space-before-closing`.
+
 # 1.1.0
 
 - Updated ESLint to version 5.

--- a/packages/eslint-config-adidas-react/index.js
+++ b/packages/eslint-config-adidas-react/index.js
@@ -132,7 +132,6 @@ module.exports = {
       'error',
       { noSortAlphabetically: true, callbacksLast: true }
     ],
-    'react/jsx-space-before-closing': [ 'error', 'never' ],
     'react/jsx-tag-spacing': [
       'error', {
         closingSlash: 'never',

--- a/packages/eslint-config-adidas-react/package.json
+++ b/packages/eslint-config-adidas-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-adidas-react",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "ESLint configuration and rules for React codebases",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
- Removed deprecated rule `react/jsx-space-before-closing`.
- Updated TravisCI configuration to deploy on tags on `master` branch.

Fixed related to issue #8, thanks to @guidobonnet.