### PR TITLE
FIX @typescript-eslint/type-annotation-spacing config for arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ This changelog is only to log changes of the project base.
 If there are changes on the packages, please, check and update the changelog of each package accordingly.
 -->
 
+## 1.5.1
+
+- Fixed missing configuration for `@typescript-eslint/type-annotation-spacing`.
+
 # 1.5.0
 
 - Added `eslint-config-adidas-typescript` configuration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "js-linter-configs",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-linter-configs",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "adidas configurations for JavaScript linting tools",
   "license": "MIT",
   "contributors": [

--- a/packages/eslint-config-adidas-typescript/CHANGELOG.md
+++ b/packages/eslint-config-adidas-typescript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- Fixed missing configuration for `@typescript-eslint/type-annotation-spacing`.
+
 # 1.0.0
 
 - Initial version: `eslint-config-adidas-typescript`.

--- a/packages/eslint-config-adidas-typescript/index.js
+++ b/packages/eslint-config-adidas-typescript/index.js
@@ -261,7 +261,13 @@ module.exports = {
       'error',
       {
         before: false,
-        after: true
+        after: true,
+        overrides: {
+          arrow: {
+            before: true,
+            after: true
+          }
+        }
       }
     ],
     '@typescript-eslint/unbound-method': [

--- a/packages/eslint-config-adidas-typescript/package.json
+++ b/packages/eslint-config-adidas-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-adidas-typescript",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ESLint base configuration and rules for TypeScript codebases",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
<!-- Give us an overview of your changes -->

Before, the configuration required arrows in types to be like this:

```
export type OnMessage = (message: string)=> void;
```

It should require arrows to have a space before like this instead:

```
export type OnMessage = (message: string) => void;
```