### PR TITLE
UPGRADE typescript-eslint dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ This changelog is only to log changes of the project base.
 If there are changes on the packages, please, check and update the changelog of each package accordingly.
 -->
 
+# 1.6.0
+
+- Upgraded `eslint-config-adidas-typescript` dependencies and rules.
+
 ## 1.5.1
 
 - Fixed missing configuration for `@typescript-eslint/type-annotation-spacing`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "js-linter-configs",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-linter-configs",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "adidas configurations for JavaScript linting tools",
   "license": "MIT",
   "contributors": [

--- a/packages/eslint-config-adidas-typescript/CHANGELOG.md
+++ b/packages/eslint-config-adidas-typescript/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.1.0
+
+- Upgraded `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin` to v2.4.0.
+- Upgraded peer version of `eslint` to v6.
+- Fixed rule configuration for `@typescript-eslint/array-type`.
+- Removed deprecated rules.
+
 ## 1.0.1
 
 - Fixed missing configuration for `@typescript-eslint/type-annotation-spacing`.

--- a/packages/eslint-config-adidas-typescript/index.js
+++ b/packages/eslint-config-adidas-typescript/index.js
@@ -22,7 +22,7 @@ module.exports = {
     'no-useless-constructor': 'off',
     'semi': 'off',
     '@typescript-eslint/adjacent-overload-signatures': 'error',
-    '@typescript-eslint/array-type': [ 'error', 'generic' ],
+    '@typescript-eslint/array-type': [ 'error', { readonly: 'generic', default: 'generic' }],
     '@typescript-eslint/await-thenable': 'error',
     '@typescript-eslint/ban-ts-ignore': 'error',
     '@typescript-eslint/ban-types': [
@@ -54,6 +54,7 @@ module.exports = {
       }
     ],
     '@typescript-eslint/class-name-casing': 'error',
+    '@typescript-eslint/consistent-type-assertions': 'error',
     '@typescript-eslint/consistent-type-definitions': 'off',
     '@typescript-eslint/explicit-function-return-type': [
       'error',
@@ -155,7 +156,6 @@ module.exports = {
         ]
       }
     ],
-    '@typescript-eslint/no-angle-bracket-type-assertion': 'error',
     '@typescript-eslint/no-array-constructor': 'error',
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-empty-interface': 'error',
@@ -195,7 +195,6 @@ module.exports = {
       }
     ],
     '@typescript-eslint/no-non-null-assertion': 'error',
-    '@typescript-eslint/no-object-literal-type-assertion': 'error',
     '@typescript-eslint/no-parameter-properties': 'off',
     '@typescript-eslint/no-require-imports': 'off',
     '@typescript-eslint/no-this-alias': [
@@ -231,7 +230,6 @@ module.exports = {
     '@typescript-eslint/prefer-for-of': 'error',
     '@typescript-eslint/prefer-function-type': 'off',
     '@typescript-eslint/prefer-includes': 'error',
-    '@typescript-eslint/prefer-interface': 'off',
     '@typescript-eslint/prefer-namespace-keyword': 'error',
     '@typescript-eslint/prefer-readonly': [
       'error',

--- a/packages/eslint-config-adidas-typescript/package.json
+++ b/packages/eslint-config-adidas-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-adidas-typescript",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "ESLint base configuration and rules for TypeScript codebases",
   "license": "MIT",
   "contributors": [
@@ -17,12 +17,12 @@
   },
   "main": "./index.js",
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^1.12",
-    "@typescript-eslint/parser": "^1.13",
+    "@typescript-eslint/eslint-plugin": "^2.4",
+    "@typescript-eslint/parser": "^2.4",
     "eslint-config-adidas-es9": "^1.1"
   },
   "peerDependencies": {
-    "eslint": "^5"
+    "eslint": "^6"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
<!-- Give us an overview of your changes -->

Upgraded `@typescript-eslint` dependencies due to errors when parsing some expressions.
Require `eslint@6` for `eslint-config-adidas-typescript`.