### PR TITLE
Improve double slash comment rule in SCSS

### DIFF
--- a/packages/stylelint-config-adidas-scss/index.js
+++ b/packages/stylelint-config-adidas-scss/index.js
@@ -48,7 +48,13 @@ module.exports = {
     'scss/dollar-variable-no-missing-interpolation': true,
     'scss/dollar-variable-pattern': null,
     'scss/percent-placeholder-pattern': null,
-    'scss/double-slash-comment-empty-line-before': 'always',
+    'scss/double-slash-comment-empty-line-before': [
+      'always',
+      {
+        except: [ 'first-nested' ],
+        ignore: [ 'between-comments', 'stylelint-commands' ]
+      }
+    ],
     'scss/double-slash-comment-inline': [
       'never',
       {


### PR DESCRIPTION
Hi, I am from adidas Design Language team and we are adopting the stylelint and eslint config to our project.

This patch will make the following code valid:

```scss
// If we want
// to have
// a very long
// comment
```

Without the patch, it will be formatted as:

```scss
// If we want

// to have

// a very long

// comment
```