### PR TITLE
Use long hex format for colors

### DIFF
--- a/packages/stylelint-config-adidas/index.js
+++ b/packages/stylelint-config-adidas/index.js
@@ -31,7 +31,7 @@ module.exports = {
     'block-opening-brace-space-after': 'always-single-line',
     'block-opening-brace-space-before': 'always',
     'color-hex-case': 'lower',
-    'color-hex-length': 'short',
+    'color-hex-length': 'long',
     'color-named': null,
     'color-no-hex': null,
     'color-no-invalid-hex': true,


### PR DESCRIPTION
In both adidas Design Language and GLASS, the long hex format `#ffffff` is more widely used than the short hex format `#fff`. When ever the design is delivered from designers to developers, the color values are in long hex format.

