### PR TITLE
Don't extends stylelint-config-standard so it is compatible with Prettier

### DIFF
--- a/packages/stylelint-config-adidas-bem/README.md
+++ b/packages/stylelint-config-adidas-bem/README.md
@@ -9,16 +9,17 @@ It uses the BEM pattern plugin with some custom rules: [_stylelint-selector-bem-
 ## Install
 
 ```
-npm i --save-dev stylelint@9 stylelint-config-adidas stylelint-config-adidas-bem
+npm i --save-dev stylelint@9 stylelint-config-standard stylelint-config-adidas stylelint-config-adidas-bem
 ```
 
 ## Project specific configuration.
 
-Create a `.stylelintrc` file on the root folder of the project.
+Create a `.stylelintrc.json` file on the root folder of the project.
 
 ```json
 {
   "extends": [
+    "stylelint-config-standard",
     "stylelint-config-adidas",
     "stylelint-config-adidas-bem"
   ]

--- a/packages/stylelint-config-adidas-scss/README.md
+++ b/packages/stylelint-config-adidas-scss/README.md
@@ -9,16 +9,17 @@ It uses the SCSS plugin with some custom rules: [_stylelint-scss_](https://www.n
 ## Install
 
 ```
-npm i --save-dev stylelint@9 stylelint-scss@3 stylelint-config-adidas stylelint-config-adidas-scss
+npm i --save-dev stylelint@9 stylelint-scss@3 stylelint-config-standard stylelint-config-adidas stylelint-config-adidas-scss
 ```
 
 ## Project specific configuration.
 
-Create a `.stylelintrc` file on the root folder of the project.
+Create a `.stylelintrc.json` file on the root folder of the project.
 
 ```json
 {
   "extends": [
+    "stylelint-config-standard",
     "stylelint-config-adidas",
     "stylelint-config-adidas-scss"
   ]

--- a/packages/stylelint-config-adidas/README.md
+++ b/packages/stylelint-config-adidas/README.md
@@ -9,16 +9,19 @@ The configuration extends the _stylelint_ standard: [_stylelint-config-standard_
 ## Install
 
 ```
-npm i --save-dev stylelint@9 stylelint-config-adidas
+npm i --save-dev stylelint@9 stylelint-config-standard stylelint-config-adidas
 ```
 
 ## Project specific configuration.
 
-Create a `.stylelintrc` file on the root folder of the project.
+Create a `.stylelintrc.json` file on the root folder of the project.
 
 ```json
 {
-  "extends": "stylelint-config-adidas"
+  "extends": [
+    "stylelint-config-standard",
+    "stylelint-config-adidas"
+  ]
 }
 ```
 

--- a/packages/stylelint-config-adidas/index.js
+++ b/packages/stylelint-config-adidas/index.js
@@ -1,5 +1,4 @@
 module.exports = {
-  extends: [ 'stylelint-config-standard' ],
   rules: {
     'at-rule-blacklist': null,
     'at-rule-empty-line-before': [

--- a/packages/stylelint-config-adidas/package.json
+++ b/packages/stylelint-config-adidas/package.json
@@ -19,9 +19,6 @@
   "peerDependencies": {
     "stylelint": "^9.9"
   },
-  "dependencies": {
-    "stylelint-config-standard": "18.2.0"
-  },
   "files": [
     "index.js",
     "README.md",


### PR DESCRIPTION
`stylelint-config-standard` is incompatible with Prettier. Prettier requires `stylelint-config-recommended` instead.

This PR make it possible to choose `stylelint-config-standard` or `stylelint-config-recommended` for different project needs.

Both aDL and GLASS are using Prettier at the moment.