### PR TITLE
eslint-config-adidas-typescript: disable valid-jsdoc

### DIFF
--- a/packages/eslint-config-adidas-typescript/index.js
+++ b/packages/eslint-config-adidas-typescript/index.js
@@ -22,6 +22,7 @@ module.exports = {
     'no-useless-constructor': 'off',
     'semi': 'off',
     'space-before-function-paren': 'off',
+    'valid-jsdoc': 'off',
     '@typescript-eslint/adjacent-overload-signatures': 'error',
     '@typescript-eslint/array-type': [ 'error', { readonly: 'generic', default: 'generic' }],
     '@typescript-eslint/await-thenable': 'error',


### PR DESCRIPTION
In TypeScript project, sometimes the function can explain itself very well and here is no need to document parameters and returns:

```ts
/**
 * ID should only contain letters, numbers, dashes and dots
 */
export function validateId(id: string): boolean | undefined {
  if (id.length === 0) {
    return
  }

  const match = id.match(/[A-Za-z0-9\-.]*/)

  if (match && match.length && match[0] === id) {
    return true
  }

  return false
}
```

<!-- Give us an overview of your changes -->
