### PR TITLE
ADJUST rules after testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ This changelog is only to log changes of the project base.
 If there are changes on the packages, please, check and update the changelog of each package accordingly.
 -->
 
+## 1.9.1
+
+- Updated rules for `eslint-config-adidas-es5`, `eslint-config-adidas-es9` and `eslint-config-adidas-typescript`.
+
 # 1.9.0
 
 - Updated eslint to v7.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-linter-configs",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "adidas configurations for JavaScript linting tools",
   "license": "MIT",
   "contributors": [

--- a/packages/eslint-config-adidas-es5/CHANGELOG.md
+++ b/packages/eslint-config-adidas-es5/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1
+
+- Disabled `require-unicode-regexp`.
+
 # 1.3.0
 
 - Updated ESLint to version 7.

--- a/packages/eslint-config-adidas-es5/index.js
+++ b/packages/eslint-config-adidas-es5/index.js
@@ -310,7 +310,7 @@ module.exports = {
     'require-atomic-updates': 'off',
     'require-await': 'off',
     'require-jsdoc': 'off',
-    'require-unicode-regexp': 'error',
+    'require-unicode-regexp': 'off',
     'require-yield': 'off',
     'rest-spread-spacing': 'off',
     'semi-spacing': [ 'error', { before: false, after: true }],

--- a/packages/eslint-config-adidas-es9/CHANGELOG.md
+++ b/packages/eslint-config-adidas-es9/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1
+
+- Disabled `prefer-named-capture-group`.
+
 # 1.3.0
 
 - Updated ESLint to version 7.

--- a/packages/eslint-config-adidas-es9/index.js
+++ b/packages/eslint-config-adidas-es9/index.js
@@ -4,7 +4,7 @@ module.exports = {
     ecmaVersion: 9
   },
   rules: {
-    'prefer-named-capture-group': 'error',
+    'prefer-named-capture-group': 'off',
     'prefer-object-spread': 'error'
   }
 };

--- a/packages/eslint-config-adidas-typescript/CHANGELOG.md
+++ b/packages/eslint-config-adidas-typescript/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.1
+
+- Disabled `@typescript-eslint/explicit-function-return-type` and `@typescript-eslint/no-unnecessary-condition`.
+- Updated `@typescript-eslint/naming-convention`.
+
 # 1.4.0
 
 - Updated ESLint to version 7.

--- a/packages/eslint-config-adidas-typescript/index.js
+++ b/packages/eslint-config-adidas-typescript/index.js
@@ -40,14 +40,7 @@ module.exports = {
     '@typescript-eslint/consistent-type-assertions': 'error',
     '@typescript-eslint/consistent-type-definitions': 'off',
     '@typescript-eslint/consistent-type-imports': 'off',
-    '@typescript-eslint/explicit-function-return-type': [
-      'error',
-      {
-        allowExpressions: true,
-        allowTypedFunctionExpressions: false,
-        allowHigherOrderFunctions: false
-      }
-    ],
+    '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-member-accessibility': [
       'error',
       {
@@ -98,7 +91,32 @@ module.exports = {
       }
     ],
     '@typescript-eslint/method-signature-style': [ 'error', 'method' ],
-    '@typescript-eslint/naming-convention': 'error',
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'default',
+        format: [ 'camelCase' ],
+        leadingUnderscore: 'allow',
+        trailingUnderscore: 'allow'
+      },
+
+      {
+        selector: 'variable',
+        format: [ 'camelCase', 'UPPER_CASE' ],
+        leadingUnderscore: 'allow',
+        trailingUnderscore: 'allow'
+      },
+
+      {
+        selector: [ 'property', 'parameter' ],
+        format: null
+      },
+
+      {
+        selector: 'typeLike',
+        format: [ 'PascalCase' ]
+      }
+    ],
     '@typescript-eslint/no-base-to-string': 'error',
     '@typescript-eslint/no-confusing-non-null-assertion': 'off',
     '@typescript-eslint/no-confusing-void-expression': 'off',
@@ -140,7 +158,7 @@ module.exports = {
     ],
     '@typescript-eslint/no-type-alias': 'off',
     '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
-    '@typescript-eslint/no-unnecessary-condition': 'error',
+    '@typescript-eslint/no-unnecessary-condition': 'off',
     '@typescript-eslint/no-unnecessary-qualifier': 'error',
     '@typescript-eslint/no-unnecessary-type-arguments': 'error',
     '@typescript-eslint/no-unnecessary-type-assertion': 'error',


### PR DESCRIPTION
<!-- Give us an overview of your changes -->

Disable excessive rules and adjust naming convention for TypeScript.