### PR TITLE
Updated typescript config

### DIFF
--- a/packages/eslint-config-adidas-typescript/index.js
+++ b/packages/eslint-config-adidas-typescript/index.js
@@ -108,11 +108,6 @@ module.exports = {
       },
 
       {
-        selector: [ 'property', 'parameter' ],
-        format: null
-      },
-
-      {
         selector: 'typeLike',
         format: [ 'PascalCase' ]
       }


### PR DESCRIPTION
Removed placeholder

```
{
        selector: [ 'property', 'parameter' ],
        format: null
      },
```

This throws an error with `eslint@7.18.0`

<!-- Give us an overview of your changes -->
