### PR TITLE
FIX eslint-config-adidas-babel parserOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ This changelog is only to log changes of the project base.
 If there are changes on the packages, please, check and update the changelog of each package accordingly.
 -->
 
+## 1.9.4
+
+- Fixed configuration for `eslint-config-adidas-babel`.
+
 ## 1.9.3
 
 - Fixed semver of required patch versions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "js-linter-configs",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-linter-configs",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "adidas configurations for JavaScript linting tools",
   "license": "MIT",
   "contributors": [

--- a/packages/eslint-config-adidas-babel/CHANGELOG.md
+++ b/packages/eslint-config-adidas-babel/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1
+
+- Fixed `parserOptions` to not require config file on packages from `node_modules`.  [babel/babel#11975](https://github.com/babel/babel/issues/11975)
+
 # 1.3.0
 
 - Updated ESLint to version 7.

--- a/packages/eslint-config-adidas-babel/index.js
+++ b/packages/eslint-config-adidas-babel/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   parser: '@babel/eslint-parser',
   parserOptions: {
+    requireConfigFile: false,
     allowImportExportEverywhere: false,
     ecmaFeatures: {
       experimentalObjectRestSpread: true,

--- a/packages/eslint-config-adidas-babel/package.json
+++ b/packages/eslint-config-adidas-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-adidas-babel",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "ESLint configuration to use @babel/eslint-parser",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
<!-- Give us an overview of your changes -->
Related issue: https://github.com/babel/babel/issues/11975

Linter complains when parsing some files because it looks (unexpectedly?) into node_modules for babel configurations, being unable to parse some of the files.