### PR TITLE
FIX no duplicate imports deprecated rule

### DIFF
--- a/packages/eslint-config-adidas-typescript/CHANGELOG.md
+++ b/packages/eslint-config-adidas-typescript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Replaced `@typescript-eslint/no-duplicate-imports` to `import/no-duplicates` since the former [is deprecated](https://typescript-eslint.io/rules/no-duplicate-imports/).
+
 ## 2.0.0
 
 - Updated ESLint to version 8.

--- a/packages/eslint-config-adidas-typescript/index.js
+++ b/packages/eslint-config-adidas-typescript/index.js
@@ -306,7 +306,7 @@ module.exports = {
     '@typescript-eslint/no-dupe-class-members': 'error',
 
     'no-duplicate-imports': 'off',
-    '@typescript-eslint/no-duplicate-imports': 'error',
+    'import/no-duplicates': 'error',
 
     'no-empty-function': 'off',
     '@typescript-eslint/no-empty-function': 'off',

--- a/packages/eslint-config-adidas-typescript/package.json
+++ b/packages/eslint-config-adidas-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-adidas-typescript",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "ESLint base configuration and rules for TypeScript codebases",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
Find out one deprecated rule with latest updates: 
- https://typescript-eslint.io/rules/no-duplicate-imports/ 
- https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-duplicate-imports.md

Fixing them asap in this PR